### PR TITLE
Update v2ray-core url

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.5
 ENV CONFIG_JSON=none
 RUN apk add --no-cache --virtual .build-deps ca-certificates curl \
- && curl -L -H "Cache-Control: no-cache" -o /v2ray.zip https://github.com/v2ray/v2ray-core/releases/latest/download/v2ray-linux-64.zip \
+ && curl -L -H "Cache-Control: no-cache" -o /v2ray.zip https://github.com/v2fly/v2ray-core/releases/latest/download/v2ray-linux-64.zip \
  && mkdir /usr/bin/v2ray /etc/v2ray \
  && touch /etc/v2ray/config.json \
  && unzip /v2ray.zip -d /usr/bin/v2ray \


### PR DESCRIPTION
Please refer to https://github.com/v2fly/v2ray-core/releases for further updates instead of the V2Ray release page. Currently, update in V2Fly will be mirrored to the V2Ray release page but this will NOT continue indefinitely.